### PR TITLE
fix: autoloader resolve

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ollama-mcp",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ollama-mcp",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "AGPL-3.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ollama-mcp",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "MCP server for Ollama - exposes all Ollama SDK functionality through MCP tools",
   "type": "module",
   "main": "dist/index.js",
@@ -23,7 +23,7 @@
   "homepage": "https://github.com/rawveg/ollama-mcp#readme",
   "scripts": {
     "build": "tsc",
-    "test": "vitest",
+    "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "dev": "node dist/index.js",
     "prepare": "npm run build"

--- a/src/autoloader.ts
+++ b/src/autoloader.ts
@@ -32,9 +32,13 @@ export async function discoverTools(): Promise<ToolDefinition[]> {
   const toolsDir = join(__dirname, 'tools');
   const files = await readdir(toolsDir);
 
-  // Filter for .ts and .js files
+  // Filter for .js files (production) or .ts files (development)
+  // Exclude test files and declaration files
   const toolFiles = files.filter(
-    (file) => (file.endsWith('.ts') || file.endsWith('.js')) && !file.endsWith('.test.ts')
+    (file) =>
+      (file.endsWith('.js') || file.endsWith('.ts')) &&
+      !file.includes('.test.') &&
+      !file.endsWith('.d.ts')
   );
 
   const tools: ToolDefinition[] = [];


### PR DESCRIPTION
This pull request includes minor updates to the `package.json` configuration and improves the filtering logic in the `discoverTools` function to better exclude non-tool files. The most notable changes are:

**Tool Discovery Improvements:**

* Updated the file filtering logic in `src/autoloader.ts` to exclude test files and TypeScript declaration files when discovering tools, ensuring only relevant `.js` and `.ts` files are loaded.

**Package Configuration Updates:**

* Bumped the package version from `2.0.0` to `2.0.1` in `package.json`.
* Changed the `test` script in `package.json` to use `vitest run` for consistency with coverage and CI usage.