### PR TITLE
Perf: Implement tool caching to reduce filesystem I/O

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Add to your Cline MCP settings (`cline_mcp_settings.json`):
       "command": "npx",
       "args": ["-y", "ollama-mcp"],
       "env": {
-        "OLLAMA_HOST": "http://localhost:11434"
+        "OLLAMA_HOST": "http://127.0.0.1:11434"
       }
     }
   }

--- a/src/autoloader.ts
+++ b/src/autoloader.ts
@@ -25,33 +25,55 @@ export interface ToolDefinition {
   ) => Promise<string>;
 }
 
+let cachedToolsPromise: Promise<ToolDefinition[]> | null = null;
+
+/**
+ * Reset the tool cache (primarily for testing)
+ */
+export function resetToolCache(): void {
+  cachedToolsPromise = null;
+}
+
 /**
  * Discover and load all tools from the tools directory
  */
 export async function discoverTools(): Promise<ToolDefinition[]> {
-  const toolsDir = join(__dirname, 'tools');
-  const files = await readdir(toolsDir);
-
-  // Filter for .js files (production) or .ts files (development)
-  // Exclude test files and declaration files
-  const toolFiles = files.filter(
-    (file) =>
-      (file.endsWith('.js') || file.endsWith('.ts')) &&
-      !file.includes('.test.') &&
-      !file.endsWith('.d.ts')
-  );
-
-  const tools: ToolDefinition[] = [];
-
-  for (const file of toolFiles) {
-    const toolPath = join(toolsDir, file);
-    const module = await import(toolPath);
-
-    // Check if module exports tool metadata
-    if (module.toolDefinition) {
-      tools.push(module.toolDefinition);
-    }
+  if (cachedToolsPromise) {
+    return cachedToolsPromise;
   }
 
-  return tools;
+  cachedToolsPromise = (async () => {
+    try {
+      const toolsDir = join(__dirname, 'tools');
+      const files = await readdir(toolsDir);
+
+      // Filter for .js files (production) or .ts files (development)
+      // Exclude test files and declaration files
+      const toolFiles = files.filter(
+        (file) =>
+          (file.endsWith('.js') || file.endsWith('.ts')) &&
+          !file.includes('.test.') &&
+          !file.endsWith('.d.ts')
+      );
+
+      const tools: ToolDefinition[] = [];
+
+      for (const file of toolFiles) {
+        const toolPath = join(toolsDir, file);
+        const module = await import(toolPath);
+
+        // Check if module exports tool metadata
+        if (module.toolDefinition) {
+          tools.push(module.toolDefinition);
+        }
+      }
+
+      return Object.freeze(tools) as ToolDefinition[];
+    } catch (error) {
+      cachedToolsPromise = null;
+      throw error;
+    }
+  })();
+
+  return cachedToolsPromise;
 }

--- a/tests/autoloader.test.ts
+++ b/tests/autoloader.test.ts
@@ -1,7 +1,22 @@
-import { describe, it, expect } from 'vitest';
-import { discoverTools } from '../src/autoloader.js';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs/promises')>();
+  return {
+    ...actual,
+    readdir: vi.fn(actual.readdir),
+  };
+});
+
+import { discoverTools, resetToolCache } from '../src/autoloader.js';
+import { readdir } from 'fs/promises';
 
 describe('Tool Autoloader', () => {
+  beforeEach(() => {
+    resetToolCache();
+    vi.mocked(readdir).mockClear();
+  });
+
   it('should discover all .ts files in tools directory', async () => {
     const tools = await discoverTools();
 
@@ -25,5 +40,34 @@ describe('Tool Autoloader', () => {
       expect(typeof tool.inputSchema).toBe('object');
       expect(typeof tool.handler).toBe('function');
     });
+  });
+
+  it('should cache discovered tools and call readdir exactly once', async () => {
+    // Initial state check
+    expect(readdir).not.toHaveBeenCalled();
+
+    // Multiple parallel and sequential calls should only trigger a single readdir
+    const [tools1, tools2] = await Promise.all([
+      discoverTools(),
+      discoverTools()
+    ]);
+    
+    await discoverTools();
+
+    expect(readdir).toHaveBeenCalledTimes(1);
+    expect(tools1).toBe(tools2); // Should return the same frozen array
+    expect(Object.isFrozen(tools1)).toBe(true);
+  });
+
+  it('should clear cache on error', async () => {
+    vi.mocked(readdir).mockRejectedValueOnce(new Error('FS Error'));
+    
+    await expect(discoverTools()).rejects.toThrow('FS Error');
+    expect(readdir).toHaveBeenCalledTimes(1);
+
+    // Second call should retry since first failed
+    vi.mocked(readdir).mockResolvedValueOnce([]);
+    await discoverTools();
+    expect(readdir).toHaveBeenCalledTimes(2);
   });
 });

--- a/tests/integration/server.test.ts
+++ b/tests/integration/server.test.ts
@@ -7,27 +7,29 @@ import { Ollama } from 'ollama';
 // Mock the Ollama SDK
 vi.mock('ollama', () => {
   return {
-    Ollama: vi.fn().mockImplementation(() => ({
-      list: vi.fn().mockResolvedValue({
-        models: [
-          {
-            name: 'llama2:latest',
-            size: 3825819519,
-            digest: 'abc123',
-            modified_at: '2024-01-01T00:00:00Z',
-          },
-        ],
-      }),
-      ps: vi.fn().mockResolvedValue({
-        models: [
-          {
-            name: 'llama2:latest',
-            size: 3825819519,
-            size_vram: 3825819519,
-          },
-        ],
-      }),
-    })),
+    Ollama: vi.fn().mockImplementation(function () {
+      return {
+        list: vi.fn().mockResolvedValue({
+          models: [
+            {
+              name: 'llama2:latest',
+              size: 3825819519,
+              digest: 'abc123',
+              modified_at: '2024-01-01T00:00:00Z',
+            },
+          ],
+        }),
+        ps: vi.fn().mockResolvedValue({
+          models: [
+            {
+              name: 'llama2:latest',
+              size: 3825819519,
+              size_vram: 3825819519,
+            },
+          ],
+        }),
+      };
+    }),
   };
 });
 
@@ -45,7 +47,7 @@ describe('MCP Server Integration', () => {
     const { createServer } = await import('../../src/server.js');
 
     // Create a mock Ollama instance
-    const mockOllama = new Ollama({ host: 'http://localhost:11434' });
+    const mockOllama = new Ollama({ host: 'http://127.0.0.1:11434' });
     server = createServer(mockOllama);
 
     // Create client


### PR DESCRIPTION
### Description
This PR introduces a caching layer for tool discovery in the autoloader, significantly reducing filesystem I/O and dynamic import overhead on every request.

### Why this approach?
1. **Promise Caching:** Instead of caching the resolved tool array, we cache the in-flight `Promise`. This prevents a race condition where multiple concurrent first-requests would all trigger the filesystem scan and module loading simultaneously.
2. **Immutability:** The cached array is `Object.freeze()`'d. Since the same array reference is returned to all callers, this prevents a consumer from accidentally mutating the cached tools (e.g., pushing or sorting), which would poison the cache for future requests.
3. **Test Isolation:** Exported a `resetToolCache()` utility to ensure tests can cleanly reset the module state without resorting to brittle `vi.resetModules()` gymnastics.



Resolves #17
