### PR TITLE
Fix: Implement AbortSignal propagation for request cancellation

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -30,8 +30,6 @@ export function createServer(ollamaInstance?: Ollama): Server {
     };
   }
 
-  const ollama = ollamaInstance || new Ollama(ollamaConfig);
-
   // Create MCP server
   const server = new Server(
     {
@@ -59,12 +57,37 @@ export function createServer(ollamaInstance?: Ollama): Server {
   });
 
   // Register tool call handler
-  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  server.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
     try {
+      if (extra.signal.aborted) {
+        throw new Error('Request cancelled');
+      }
+
       const { name, arguments: args } = request.params;
+
+      // Create a scoped Ollama client to support request cancellation.
+      // If a custom instance was provided, we use it directly (cancellation won't be injected).
+      // Otherwise, we create a new instance with a custom fetch that injects the AbortSignal.
+      const scopedOllama = ollamaInstance || new Ollama({
+        ...ollamaConfig,
+        fetch: (input, init) => {
+          // Combine signals if the SDK already supplied one
+          const sig = init?.signal
+            ? AbortSignal.any([init.signal, extra.signal])
+            : extra.signal;
+          return fetch(input, {
+            ...init,
+            signal: sig,
+          });
+        },
+      });
 
       // Discover all tools
       const tools = await discoverTools();
+
+      if (extra.signal.aborted) {
+        throw new Error('Request cancelled');
+      }
 
       // Find the matching tool
       const tool = tools.find((t) => t.name === name);
@@ -80,7 +103,7 @@ export function createServer(ollamaInstance?: Ollama): Server {
 
       // Call the tool handler
       const result = await tool.handler(
-        ollama,
+        scopedOllama,
         args as Record<string, unknown>,
         format
       );
@@ -105,8 +128,13 @@ export function createServer(ollamaInstance?: Ollama): Server {
         ],
       };
     } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : String(error);
+      const isAbortError = error instanceof Error && 
+        (error.name === 'AbortError' || error.message === 'Request cancelled');
+        
+      const errorMessage = isAbortError 
+        ? 'Request cancelled' 
+        : (error instanceof Error ? error.message : String(error));
+        
       return {
         content: [
           {

--- a/tests/integration/server.test.ts
+++ b/tests/integration/server.test.ts
@@ -3,31 +3,35 @@ import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { Ollama } from 'ollama';
+import { CallToolRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import { createServer } from '../../src/server.js';
 
 // Mock the Ollama SDK
 vi.mock('ollama', () => {
   return {
-    Ollama: vi.fn().mockImplementation(() => ({
-      list: vi.fn().mockResolvedValue({
-        models: [
-          {
-            name: 'llama2:latest',
-            size: 3825819519,
-            digest: 'abc123',
-            modified_at: '2024-01-01T00:00:00Z',
-          },
-        ],
-      }),
-      ps: vi.fn().mockResolvedValue({
-        models: [
-          {
-            name: 'llama2:latest',
-            size: 3825819519,
-            size_vram: 3825819519,
-          },
-        ],
-      }),
-    })),
+    Ollama: vi.fn().mockImplementation(function () {
+      return {
+        list: vi.fn().mockResolvedValue({
+          models: [
+            {
+              name: 'llama2:latest',
+              size: 3825819519,
+              digest: 'abc123',
+              modified_at: '2024-01-01T00:00:00Z',
+            },
+          ],
+        }),
+        ps: vi.fn().mockResolvedValue({
+          models: [
+            {
+              name: 'llama2:latest',
+              size: 3825819519,
+              size_vram: 3825819519,
+            },
+          ],
+        }),
+      };
+    }),
   };
 });
 
@@ -121,5 +125,72 @@ describe('MCP Server Integration', () => {
 
     expect(response.isError).toBe(true);
     expect(response.content[0].text).toContain('Unknown tool');
+  });
+
+  it('should inject AbortSignal into scoped Ollama fetch on tool call', async () => {
+    const setRequestHandlerSpy = vi.spyOn(Server.prototype, 'setRequestHandler');
+    
+    createServer();
+    
+    const callToolCall = setRequestHandlerSpy.mock.calls.find(call => call[0] === CallToolRequestSchema);
+    expect(callToolCall).toBeDefined();
+    
+    const handler = callToolCall![1];
+    
+    vi.mocked(Ollama).mockClear();
+    
+    const controller = new AbortController();
+    const mockAbortSignal = controller.signal;
+    
+    const request = {
+      params: {
+        name: 'ollama_list',
+        arguments: { format: 'json' }
+      }
+    };
+    
+    const extra = { signal: mockAbortSignal };
+    
+    await handler(request as any, extra as any);
+    
+    expect(Ollama).toHaveBeenCalledTimes(1);
+    const ollamaConfig = vi.mocked(Ollama).mock.calls[0][0];
+    
+    expect(ollamaConfig.fetch).toBeDefined();
+    
+    const globalFetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue(new Response());
+    
+    await ollamaConfig.fetch!('http://localhost:11434/api/tags', { method: 'GET' });
+    
+    expect(globalFetchSpy).toHaveBeenCalledWith('http://localhost:11434/api/tags', expect.objectContaining({
+      method: 'GET',
+      signal: mockAbortSignal
+    }));
+    
+    globalFetchSpy.mockRestore();
+    setRequestHandlerSpy.mockRestore();
+  });
+
+  it('should handle pre-aborted requests correctly', async () => {
+    const setRequestHandlerSpy = vi.spyOn(Server.prototype, 'setRequestHandler');
+    createServer();
+    const callToolCall = setRequestHandlerSpy.mock.calls.find(call => call[0] === CallToolRequestSchema);
+    const handler = callToolCall![1];
+    
+    const controller = new AbortController();
+    controller.abort();
+    
+    const request = {
+      params: { name: 'ollama_list', arguments: {} }
+    };
+    
+    const extra = { signal: controller.signal };
+    
+    const result = await handler(request as any, extra as any);
+    
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Request cancelled');
+    
+    setRequestHandlerSpy.mockRestore();
   });
 });


### PR DESCRIPTION
### Description
This PR implements request cancellation, allowing clients to cleanly abort long-running LLM generation tasks via the MCP `AbortSignal`.

### Why this approach?
1. **Scoped Client Injection:** We create a lightweight, per-request scoped Ollama client. We override its internal `fetch` implementation to inject the `extra.signal` provided by the MCP server. This natively cancels the underlying HTTP request the moment the client aborts.
2. **Safe Signal Merging:** Instead of blindly overwriting the `fetch` options' signal, we use `AbortSignal.any()` to merge the MCP cancellation signal with any internal signals the Ollama SDK might be using (e.g., for timeouts or keep-alives). This prevents us from unintentionally breaking SDK internals.
3. **Early Short-Circuit:** We check `extra.signal.aborted` at the very beginning of the handler. If the request was cancelled while waiting in the queue, we immediately throw an `AbortError`, saving the overhead of tool discovery and API calls entirely.



Resolves #16
